### PR TITLE
ci: remove usage from catalog manifest

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2023-06-08T08:16:58Z",
+  "generated_at": "2023-11-02T14:24:16Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -77,16 +77,6 @@
     }
   ],
   "results": {
-    "ibm_catalog.json": [
-      {
-        "hashed_secret": "8ac77030fe4e9ec1df27644599dda47a43d4209d",
-        "is_secret": false,
-        "is_verified": false,
-        "line_number": 105,
-        "type": "Secret Keyword",
-        "verified_result": null
-      }
-    ],
     "module-metadata.json": [
       {
         "hashed_secret": "50c5527d09191147222b2280e363ac8ef97bfa3a",

--- a/ibm_catalog.json
+++ b/ibm_catalog.json
@@ -101,8 +101,7 @@
                             "description": "Current state of Service ID creation restriction",
                             "key": "account_iam_serviceid_creation"
                         }
-                    ],
-                    "usage": ":exclamation: **Important:** Make sure that you set the `API_DATA_IS_SENSITIVE` environment variable to `true` to hide\nsensitive information before you run Terraform operations. For more information, see the generic REST API\nprovider [documentation](https://github.com/Mastercard/terraform-provider-restapi#usage):\n\nexport API_DATA_IS_SENSITIVE=true`\n\n##############################################################################\n# Config providers\n##############################################################################\n\ndata \"ibm_iam_auth_token\" \"tokendata\" {}\n\nprovider \"restapi\" {\n  uri                  = \"https:\"\n  write_returns_object = true\n  debug                = false # set to true to show detailed logs, but use carefully as it might print API key values.\n  headers              = {\n    Authorization = data.ibm_iam_auth_token.tokendata.iam_access_token\n    Content-Type  = \"application/json\"\n    if-Match      = \"*\"\n  }\n}\n\nprovider \"ibm\" {\n  ibmcloud_api_key = var.ibmcloud_api_key\n}\n\n##############################################################################\n# Configure IAM Account settings\n##############################################################################\n\n# Replace \"main\" with a version to lock into a specific release\nmodule \"iam-account-settings\" {\n  source                       = \"git::https://github.com/terraform-ibm-modules/terraform-ibm-iam-account-settings?ref=main\"\n  allowed_ip_addresses         = var.allowed_ip_addresses\n}"
+                    ]
                 }
             ],
             "keywords": [


### PR DESCRIPTION
### Description

- remove `usage` from catalog manifest. DAs are not designed to be embedded into part of another DA solution, they are designed to be the top level solution and not called from any higher level. So in this PR, I am removing the `usage` from the DA manifest which means the DA will no long show the `Embed code` section in the UI

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
