### PR TITLE
fix(deps): update CBR and bump versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You need the following permissions to run this module.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.65.0, < 2.0.0 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >= 1.70.0, < 2.0.0 |
 
 ### Modules
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ You need the following permissions to run this module.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cbr_zones"></a> [cbr\_zones](#module\_cbr\_zones) | terraform-ibm-modules/cbr/ibm//modules/cbr-zone-module | v1.24.1 |
+| <a name="module_cbr_zones"></a> [cbr\_zones](#module\_cbr\_zones) | terraform-ibm-modules/cbr/ibm//modules/cbr-zone-module | v1.30.0 |
 
 ### Resources
 

--- a/examples/custom/version.tf
+++ b/examples/custom/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.65.0"
+      version = "1.70.0"
     }
     restapi = {
       source  = "Mastercard/restapi"

--- a/examples/default/version.tf
+++ b/examples/default/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Pin to the lowest provider version of the range defined in the main module to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.65.0"
+      version = "1.70.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ locals {
 module "cbr_zones" {
   for_each           = { for obj in var.cbr_zones : obj.name => obj }
   source             = "terraform-ibm-modules/cbr/ibm//modules/cbr-zone-module"
-  version            = "v1.24.1"
+  version            = "v1.30.0"
   account_id         = data.ibm_iam_account_settings.iam_account_settings.account_id
   name               = each.value.name
   zone_description   = each.value.zone_description

--- a/version.tf
+++ b/version.tf
@@ -4,7 +4,7 @@ terraform {
     # Each required provider's version should be a flexible range to future proof the module's usage with upcoming minor and patch versions.
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = ">= 1.65.0, < 2.0.0"
+      version = ">= 1.70.0, < 2.0.0"
     }
   }
 }


### PR DESCRIPTION
### Description
This PR addresses failures seen in https://github.com/terraform-ibm-modules/terraform-ibm-iam-account-settings/pull/348 due to the CBR version requiring a higher version of the IBM provider than the locked-in versions for the examples, bumped the required version and all of the locked versions to match requirements for CBR

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->
(taken from renovate PR)

### Release Notes

<details>
<summary>terraform-ibm-modules/terraform-ibm-cbr (terraform-ibm-modules/cbr/ibm)</summary>

### [`v1.30.0`](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/releases/tag/v1.30.0)

[Compare Source](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/compare/v1.29.1...v1.30.0)

##### Features

-   Updated services list to support CBR <br> - New supported services "atracker", "logs", "ghost-tags"<br> - Deprecated services "databases-for-cassandra", "logdna", "logdnaat" ([#&#8203;641](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/641)) ([be6a290](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/commit/be6a290c6178bed4bd5e92b1bf4f6bdf8ec7428b))

### [`v1.29.1`](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/releases/tag/v1.29.1)

[Compare Source](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/compare/v1.29.0...v1.29.1)

##### Bug Fixes

-   restrict codeengine control plane api ([#&#8203;639](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/639)) ([bce717a](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/commit/bce717a7e42d3bfdea8eefa191ea6b8f917f4d86))

### [`v1.29.0`](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/releases/tag/v1.29.0)

[Compare Source](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/compare/v1.28.1...v1.29.0)

##### Features

-   added cloud logs support to the fscloud submodule profile ([#&#8203;568](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/568))

### [`v1.28.1`](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/releases/tag/v1.28.1)

[Compare Source](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/compare/v1.28.0...v1.28.1)

##### Bug Fixes

-   **deps:** updated required provider version to >= 1.70.0 to pick up the fix for this provider issue: [\[ibm_cbr_zone\] Error: Provider produced inconsistent result after apply](https://redirect.github.com/IBM-Cloud/terraform-provider-ibm/issues/5590)([#&#8203;556](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/556)) ([93ea730](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/commit/93ea730d53e26591eeaa8408a4d1fd3dc8d3e50a))

### [`v1.28.0`](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/releases/tag/v1.28.0)

[Compare Source](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/compare/v1.27.0...v1.28.0)

##### Features

-   added two new inputs to the fscloud profile: `allow_vpcs_to_iam_groups` and `allow_vpcs_to_iam_access_management`. By setting these to true, the following FSCloud SCC rules will pass:<br>- ` Check whether IAM access management can be accessed only thorugh a private endpoint (Context-based restrictions or service) and allowed IPs<br>-  `Check whether IAM access groups can be accessed only through a private endpoint (Context-based restrictions or service) and allowed IPs\` ([#&#8203;548](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/548)) ([10c5bc9](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/commit/10c5bc93b2fa21aed322750d6f0ef049ddaa46a6))

### [`v1.27.0`](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/releases/tag/v1.27.0)

[Compare Source](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/compare/v1.26.0...v1.27.0)

##### Features

-   Enable traffic flow from SCC to COS is added ([#&#8203;525](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/525)) ([789366a](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/commit/789366abbf963ca1e2dc5c8e367a4ae391f375d5))

### [`v1.26.0`](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/releases/tag/v1.26.0)

[Compare Source](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/compare/v1.25.0...v1.26.0)

##### Features

-   added support to the `cbr-zone-module` to use existing zone using new inputs `existing_zone_id` and `use_existing_cbr_zone` ([#&#8203;530](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/530)) ([3e25409](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/commit/3e25409ee2f559f4974959b8b410c91bf6c60d73))

### [`v1.25.0`](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/releases/tag/v1.25.0)

[Compare Source](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/compare/v1.24.1...v1.25.0)

##### Features

-   updated the `target_service_details` input in the fscloud submodule to support setting the `geography` option.<br>**NOTE:** Both `region` and `geography` cannot be set simultaneously for the container registry service. ([#&#8203;519](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/519)) ([4060786](https://redirect.github.com/terraform-ibm-modules/terraform-ibm-cbr/commit/4060786ae16925b6bc088ed00861587a986445f3))

</details>

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
